### PR TITLE
bumping wordpress compatibility to 5.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:4.9.8-php7.2-apache
+FROM wordpress:5.4.0-php7.2-apache
 
 RUN apt-get update && \
 	apt-get install -y  --no-install-recommends ssl-cert && \

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Plugin URI: https://bmlt.app
 Tags: na, meeting list, meeting finder, maps, recovery, addiction, webservant
 Author: bmlt-enabled
 Requires at least: 4.0
-Tested up to: 5.2.3
+Tested up to: 5.4.0
 Stable tag: 3.10.0
 
 This is a "satellite" plugin for the Basic Meeting List Toolbox (BMLT).


### PR DESCRIPTION
I bumped all bmlt readmes in svn to 5.4 https://wordpress.org/plugins/search/bmlt/ this just updates repo